### PR TITLE
Format dates as 'day month year' without comma

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,7 +20,7 @@ export default function(eleventyConfig) {
 
   // Date filters
   eleventyConfig.addFilter("readableDate", (dateObj) => {
-    return DateTime.fromJSDate(dateObj, { zone: "utc" }).toFormat("LLLL d, yyyy");
+    return DateTime.fromJSDate(dateObj, { zone: "utc" }).toFormat("d LLLL yyyy");
   });
 
   eleventyConfig.addFilter("htmlDateString", (dateObj) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
       "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.2.tgz",
       "integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@11ty/dependency-tree": "^4.0.0",
         "@11ty/dependency-tree-esm": "^2.0.0",
@@ -1290,7 +1289,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1312,7 +1310,6 @@
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
       "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"


### PR DESCRIPTION
Changed readableDate filter from 'LLLL d, yyyy' to 'd LLLL yyyy' to produce dates in the format '6 January 2026' instead of 'January 6, 2026'.