### PR TITLE
Add hide_tidytuesday_link flag to control link visibility

### DIFF
--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -8,9 +8,11 @@ layout: base.njk
       <time datetime="{{ date | htmlDateString }}">{{ date | readableDate }}</time>
     </p>
     <h1 class="post__title">{{ title }}</h1>
+    {% if not hide_tidytuesday_link %}
     <p class="post__source">
       <a href="{{ site.tidytuesday_base }}/{{ date | year }}/{{ date | htmlDateString }}">View data on TidyTuesday</a>
     </p>
+    {% endif %}
   </header>
 
   <div class="post__content">

--- a/src/posts/2026-01-06-week-01.md
+++ b/src/posts/2026-01-06-week-01.md
@@ -2,6 +2,7 @@
 title: Claude Code Adoption
 date: 2026-01-06
 week: 1
+hide_tidytuesday_link: true
 charts:
   claude-adoption:
     type: dot


### PR DESCRIPTION
- Add optional hide_tidytuesday_link frontmatter flag to posts
- Update post.njk template to conditionally render TidyTuesday link
- Enable flag for 2026-01-06 post where official TT page doesn't exist